### PR TITLE
fix: title and description at host event page

### DIFF
--- a/src/pages/host/event.tsx
+++ b/src/pages/host/event.tsx
@@ -73,9 +73,8 @@ export default function Host(): JSX.Element {
             <section>
                 <div className={styles.centerContainer}>
                     <div className={styles.textContainer}>
-                        <h1 className={styles.title}>호스트 등록 이벤트</h1>
-                        {/* <h1 className={styles.title}>호스트 등록 이벤트</h1> */}
-                        <p className={styles.subtitle}>서울 전역 호스트 9/30까지</p>
+                        <h1 className={styles.title}>{`48시간 안에 전 세계 게스트가\n당신의 문을 두드립니다!`}</h1>
+                        <p className={styles.subtitle}>외국인 게스트와 함께, 공실 걱정 없는 안정적인 수익을 잡으세요.</p>
                         <div className="container">
                             <a href="https://docs.google.com/forms/d/e/1FAIpQLSffXoKk7xgAOh3ZxFwMyWCjEZmSIv2AHDqgcm1XuueZiQU6QA/viewform"><button className={styles.button} style={{ margin: "10px", backgroundColor: "#4484F1", color: "#FFF" }}>호스트 신청하러 가기</button></a>
                             <a href="https://stay-enkor.channel.io/"><button className={styles.button} style={{ margin: "10px", backgroundColor: "#FFF" }}>호스트 가입 / 상담</button></a>

--- a/src/pages/host/styles.module.css
+++ b/src/pages/host/styles.module.css
@@ -42,6 +42,8 @@
 .title {
   font-size: var(--font-size-h1);
   font-weight: 900;
+  white-space: pre-line;
+  word-break: keep-all;
 }
 .subtitle {
   font-size: 18px;


### PR DESCRIPTION
- 호스트 이벤트 페이지 타이틀 및 디스크립션 문구 변경

| PC | 모바일 |
|--------|--------|
| ![스크린샷 2024-11-01 오후 1 34 45](https://github.com/user-attachments/assets/255c7db3-8477-41c5-9e22-3dce85ed7093) | ![스크린샷 2024-11-01 오후 1 34 57](https://github.com/user-attachments/assets/7a2c3d11-8579-49cd-acb3-b8e4dcce0985) | 

*참고: word-break 설정
![스크린샷 2024-11-01 오후 1 35 08](https://github.com/user-attachments/assets/5015c619-5d3c-40ec-bcdc-1c2a8b68eefa)

