### PR TITLE
[PR]베딩 운영사 이름 변경

### DIFF
--- a/docs/bedding/purchase.md
+++ b/docs/bedding/purchase.md
@@ -42,8 +42,7 @@ You may choose from two types of bedding sets:
 ## Move-in Date Change
 
 - Shipping dates may be changed **up to 4 days before** your move-in date.
-- To request changes, please contact our support team:  
-  📩 **service_support@enko.kr**
+- To request changes, please contact [LIVING KO, the official bedding service operator](https://linktr.ee/LIVINGKO)
 
 ---
 
@@ -87,6 +86,7 @@ Returns or exchanges will **not be accepted** if:
 
 ## 7. Important Notes
 
+- If you request cancellation through [LIVING KO](https://linktr.ee/LIVINGKO), we can process the Stripe cancellation on the same day. Once Stripe completes the cancellation, the refund will be credited to your account—this typically takes 3–5 days, depending on your card issuer.
 - All items are shipped under **strict hygiene standards**
 - Once opened, items are **not refundable** due to personal preference
 - A **10% payment processing fee** is **non-refundable** in all cancellations
@@ -97,5 +97,5 @@ Returns or exchanges will **not be accepted** if:
 
 ## 8. Customer Service Contact
 
-- **CS Link**: [Contact Living Ko, the official bedding service operator](https://linktr.ee/LIVINGKO)
+- **CS Link**: [Contact LIVING KO, the official bedding service operator](https://linktr.ee/LIVINGKO)
 - **Phone**: +82) 70 8027 1895


### PR DESCRIPTION
- 베딩 운영사 이름 변경 : Living ko => LIVING KO
- 환불 관련 문구 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 입주일 변경 요청 시 이메일 대신 공식 서비스 운영사(LIVING KO) 링크로 안내를 수정했습니다.
  * "중요 안내"에 LIVING KO를 통한 취소 시 Stripe 환불 처리 및 환불 소요 기간(3~5일)에 대한 안내를 추가했습니다.
  * 고객센터 안내에서 "Living Ko"를 "LIVING KO"로 표기 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->