### PR TITLE
채널톡 링크 제거

### DIFF
--- a/docs/housing/reservation.md
+++ b/docs/housing/reservation.md
@@ -55,7 +55,7 @@ If you are curious about the possibility of additional discounts, please contact
 
 We typically only accept payments through our official website.
 
-If you have encountered difficulties with payment despite multiple attempts on our website, please inform the [Enko service center](https://stay-enkor.channel.io).
+If you have encountered difficulties with payment despite multiple attempts on our website, please email us at [stay_support@enko.kr](mailto:stay_support@enko.kr).
 
 ### What is installment payment (monthly payment)
 

--- a/src/pages/host/event.tsx
+++ b/src/pages/host/event.tsx
@@ -153,14 +153,6 @@ export default function Host(): JSX.Element {
                   호스트 신청하러 가기
                 </button>
               </a>
-              <a href="https://stay-enkor.channel.io/">
-                <button
-                  className={styles.button}
-                  style={{ margin: "10px", backgroundColor: "#FFF" }}
-                >
-                  호스트 가입 / 상담
-                </button>
-              </a>
             </div>
           </div>
         </div>
@@ -228,14 +220,6 @@ export default function Host(): JSX.Element {
               }}
             >
               호스트 신청하러 가기
-            </button>
-          </a>
-          <a href="https://stay-enkor.channel.io/">
-            <button
-              className={styles.button}
-              style={{ margin: "10px", backgroundColor: "#FFF" }}
-            >
-              호스트 가입 / 상담
             </button>
           </a>
         </div>


### PR DESCRIPTION
###  작업 내용
- 채널톡 링크 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서화
  - 결제 어려움 안내의 연락처를 서비스센터 링크에서 이메일(stay_support@enko.kr)로 변경했습니다.
- 작업(Chores)
  - 호스트 페이지의 “호스트 가입 / 상담” 외부 채팅 유도 버튼 2곳을 제거했습니다.
  - 기존 레이아웃과 “호스트 신청하러 가기” CTA는 그대로 유지되며, 외부 채팅으로 이동하던 경로가 제거되어 페이지 내 신청 흐름이 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->