### PR TITLE
fix: replace Notion iframe embed with direct URL redirect

### DIFF
--- a/src/components/NotionEmbedFullContent/index.tsx
+++ b/src/components/NotionEmbedFullContent/index.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 
 interface NotionEmbedFullContentProps {
   src: string;
@@ -8,10 +9,18 @@ interface NotionEmbedFullContentProps {
 
 export default function NotionEmbedFullContent({
   src,
-}: NotionEmbedFullContentProps): null {
+}: NotionEmbedFullContentProps): JSX.Element | null {
   useEffect(() => {
-    window.location.replace(src);
+    if (ExecutionEnvironment.canUseDOM) {
+      window.location.replace(src);
+    }
   }, [src]);
+
+  if (!ExecutionEnvironment.canUseDOM) {
+    return (
+      <meta httpEquiv="refresh" content={`0; url=${src}`} />
+    );
+  }
 
   return null;
 }

--- a/src/components/NotionEmbedFullContent/index.tsx
+++ b/src/components/NotionEmbedFullContent/index.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import Layout from "@theme/Layout";
+import { useEffect } from "react";
 
 interface NotionEmbedFullContentProps {
   src: string;
@@ -9,47 +8,10 @@ interface NotionEmbedFullContentProps {
 
 export default function NotionEmbedFullContent({
   src,
-  title,
-  description,
-}: NotionEmbedFullContentProps): JSX.Element {
-  return (
-    <Layout title={title} description={description}>
-      <style>
-        {`
-          .notion-container {
-            width: 100%;
-            height: calc(100vh - 60px - 270px); // HACK: navbar와 footer 높이 제외
-            overflow: hidden;
-            position: relative;
-          }
-          
-          @media (max-width: 997px) {
-            .notion-container {
-              height: calc(100vh - 60px - 582px); // HACK: 모바일인 경우 navbar와 footer 높이 제외
-            }
-          }
-          
-          @media (max-height: 820px) {
-            .notion-container {
-              height: calc(100vh - 60px) !important; // HACK: 높이가 820px 이하면 footer 영역 제외하지 않음
-            }
-          }
-        `}
-      </style>
-      <div className="notion-container" style={{ position: "relative" }}>
-        <iframe
-          src={src}
-          width="100%"
-          height="100%"
-          allowFullScreen
-          style={{
-            display: "block",
-            border: "none",
-            marginTop: "-44px", // HACK: Notion navbar 높이 제외
-            height: "calc(100% + 44px)",
-          }}
-        />
-      </div>
-    </Layout>
-  );
+}: NotionEmbedFullContentProps): null {
+  useEffect(() => {
+    window.location.replace(src);
+  }, [src]);
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- Notion CSP(`frame-ancestors`)로 인해 외부 도메인에서 iframe 임베드가 차단되는 문제 수정
- `NotionEmbedFullContent` 컴포넌트의 iframe 렌더링을 `window.location.replace()`로 교체하여 Notion URL로 즉시 redirect
- 9개 정책 페이지 모두 동일 컴포넌트를 사용하므로 1개 파일 수정으로 전체 적용

## Test plan
- [x] 각 정책 페이지 접근 시 해당 Notion 페이지로 redirect 되는지 확인
- [x] 브라우저 뒤로가기 시 redirect 루프가 발생하지 않는지 확인 (`location.replace` 사용으로 히스토리에 남지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * Notion 임베드 콘텐츠가 더 이상 페이지 내에 직접 렌더링되지 않고, 제공된 링크로 즉시 이동(클라이언트 리다이렉트)합니다.
  * DOM이 없는 환경에서는 메타 리프레시 방식의 대체 동작을 사용하며, 임베드 자리에는 표시되지 않을 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->